### PR TITLE
feat:Active Input Handlingの設定変更

### DIFF
--- a/kaze-hichau/ProjectSettings/ProjectSettings.asset
+++ b/kaze-hichau/ProjectSettings/ProjectSettings.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9c0853f3d4fea867eecf6224b3de946a91ae382254ae121372f05ee2ab816e75
+oid sha256:cee75c3406e7cd5073a817e39ea87d407664734f1a4ec99cc3238300f0533701
 size 20274

--- a/kaze-hichau/ProjectSettings/SceneTemplateSettings.json
+++ b/kaze-hichau/ProjectSettings/SceneTemplateSettings.json
@@ -1,0 +1,121 @@
+{
+    "templatePinStates": [],
+    "dependencyTypeInfos": [
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimationClip",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Animations.AnimatorController",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimatorOverrideController",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Audio.AudioMixerController",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ComputeShader",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Cubemap",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.GameObject",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.LightingDataAsset",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.LightingSettings",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Material",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.MonoScript",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicsMaterial",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicsMaterial2D",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessProfile",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessResources",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.VolumeProfile",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.SceneAsset",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Shader",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ShaderVariantCollection",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture2D",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Timeline.TimelineAsset",
+            "defaultInstantiationMode": 0
+        }
+    ],
+    "defaultDependencyTypeInfo": {
+        "userAdded": false,
+        "type": "<default_scene_template_dependencies>",
+        "defaultInstantiationMode": 1
+    },
+    "newSceneOverride": 0
+}


### PR DESCRIPTION
このプルリクエストでは、プロジェクト設定を更新し、Unityのシーンテンプレート依存関係用の新しい設定ファイルを導入します。主な焦点は、シーンの作成とインスタンス化時にシーンアセットとその依存関係を管理する方法の改善にあります。

プロジェクト設定の更新:

* `ProjectSettings.asset` ファイル内のSHA256ハッシュとサイズメタデータを、プロジェクト設定の変更を反映するように更新しました。

シーンテンプレートの依存関係管理:

* さまざまなUnityアセットタイプ（例: `AnimationClip`、`AnimatorController`、`AudioMixerController`、`Shader`など）のインスタンス化モードを指定する新しい`SceneTemplateSettings.json`ファイルを追加しました。これにより、テンプレートから新しいシーンを作成する際の依存関係の処理方法を制御できます。
* シーンテンプレート用のデフォルトの依存関係タイプとインスタンス化モードを定義し、明示的にリストされていないアセットの一貫した動作を確保します。
* `newSceneOverride` プロパティを設定し、テンプレートに基づく新しいシーンの処理方法を制御します。