### PR TITLE
feat:Player Prefabの追加

### DIFF
--- a/kaze-hichau/Assets/Prefabs/Player.prefab
+++ b/kaze-hichau/Assets/Prefabs/Player.prefab
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:423332bb36371cff5d7856d903d30eb9781047c272b0ee8915a58bdd312f7d8a
+size 4482

--- a/kaze-hichau/Assets/Prefabs/Player.prefab.meta
+++ b/kaze-hichau/Assets/Prefabs/Player.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5d22cb115bfa5cd448625b8c9e0be324
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
このプルリクエストでは、プロジェクトに新しいプレイヤープレハブを追加し、ゲーム内のプレイヤーオブジェクトのインスタンス化と管理を容易にします。

新しいアセットの追加:

* `Assets/Prefabs` ディレクトリに `Player.prefab` を追加し、ゲームで再利用可能なプレイヤーオブジェクトを導入しました。
* Unityのアセット管理をサポートするため、対応するメタデータファイル `Player.prefab.meta` を追加しました。