### PR TITLE
BGMの実装とその他もろもろ

### DIFF
--- a/kaze-hichau/Assets/Music/ResultBGM.mp3
+++ b/kaze-hichau/Assets/Music/ResultBGM.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26fca8e9af564bcb48201e78843f006a4bcb1c28d9a21a0c11896eeaf3b65224
+size 271062

--- a/kaze-hichau/Assets/Music/ResultBGM.mp3.meta
+++ b/kaze-hichau/Assets/Music/ResultBGM.mp3.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 398335e572f4fae46b1287c070a26411
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 8
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/kaze-hichau/Assets/Music/Title-bgm.mp3
+++ b/kaze-hichau/Assets/Music/Title-bgm.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3e8ba6dcf6b63ed2950be7a8666f30a57871e8634e12f98cb43515e6d63517e
+size 1435500

--- a/kaze-hichau/Assets/Music/Title-bgm.mp3.meta
+++ b/kaze-hichau/Assets/Music/Title-bgm.mp3.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: f7a59d60d92168243b15285cab027a09
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 8
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/kaze-hichau/Assets/Music/gamebgm.mp3
+++ b/kaze-hichau/Assets/Music/gamebgm.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e391a13900af66c828b6be9a07cd385e4d2138e8fbfd7762f05e7efa2306ace1
+size 2525958

--- a/kaze-hichau/Assets/Music/gamebgm.mp3.meta
+++ b/kaze-hichau/Assets/Music/gamebgm.mp3.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 1b443f97cbfc36b46abea0cf7f437beb
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 8
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/kaze-hichau/Assets/Prefabs/HowToPlayScene/Canvas.prefab
+++ b/kaze-hichau/Assets/Prefabs/HowToPlayScene/Canvas.prefab
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c2b3045c123108a89eb5df3e713616093b9f0c67c3dba7d34846f489e150424b
-size 95799
+oid sha256:a8181e2d1c75da94fe3b5458b60560f91f4321d06b271360514accaf59874dff
+size 95733

--- a/kaze-hichau/Assets/Prefabs/HowToPlayScene/Play-button.png
+++ b/kaze-hichau/Assets/Prefabs/HowToPlayScene/Play-button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa0e8da631e8b5abb607cd71652f31b7be6d4240d8c352c3a22e690c42da6bfa
+size 149918

--- a/kaze-hichau/Assets/Prefabs/HowToPlayScene/Play-button.png.meta
+++ b/kaze-hichau/Assets/Prefabs/HowToPlayScene/Play-button.png.meta
@@ -1,0 +1,156 @@
+fileFormatVersion: 2
+guid: 33628394ad67c684b8614aeee2ab1ba2
+TextureImporter:
+  internalIDToNameTable:
+  - first:
+      213: -5238735815548869272
+    second: Play-button_0
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 2
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites:
+    - serializedVersion: 2
+      name: Play-button_0
+      rect:
+        serializedVersion: 2
+        x: 46
+        y: 161
+        width: 407
+        height: 174
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 865e71228854c47b0800000000000000
+      internalID: -5238735815548869272
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    outline: []
+    customData: 
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable:
+      Play-button_0: -5238735815548869272
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/kaze-hichau/Assets/Prefabs/HowToPlayScene/title-button.png
+++ b/kaze-hichau/Assets/Prefabs/HowToPlayScene/title-button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ce09d062aeb5a4680597e27acac2cdf0b966607ddf1cb4882063e5c0f38be6d
+size 1052745

--- a/kaze-hichau/Assets/Prefabs/HowToPlayScene/title-button.png.meta
+++ b/kaze-hichau/Assets/Prefabs/HowToPlayScene/title-button.png.meta
@@ -1,0 +1,156 @@
+fileFormatVersion: 2
+guid: d10dbdb55741b154b849d1499cd0aa66
+TextureImporter:
+  internalIDToNameTable:
+  - first:
+      213: -4721476582139711129
+    second: title-button_0
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 2
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites:
+    - serializedVersion: 2
+      name: title-button_0
+      rect:
+        serializedVersion: 2
+        x: 96
+        y: 320
+        width: 814
+        height: 353
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 761bc326012f97eb0800000000000000
+      internalID: -4721476582139711129
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    outline: []
+    customData: 
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable:
+      title-button_0: -4721476582139711129
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/kaze-hichau/Assets/Prefabs/TitleScene/BGMManager.prefab
+++ b/kaze-hichau/Assets/Prefabs/TitleScene/BGMManager.prefab
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59556a23d943a60dcf050f499f48838d4b48696160344a396388ddd4f984e128
+size 3698

--- a/kaze-hichau/Assets/Prefabs/TitleScene/BGMManager.prefab.meta
+++ b/kaze-hichau/Assets/Prefabs/TitleScene/BGMManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d9f8c8b2560723d4e915caf437510a47
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/kaze-hichau/Assets/Prefabs/TitleScene/title-2.png
+++ b/kaze-hichau/Assets/Prefabs/TitleScene/title-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e2e3013eb15d4eab7481050e334686374043a847c93c11554d859a40f82c289
+size 242046

--- a/kaze-hichau/Assets/Prefabs/TitleScene/title-2.png.meta
+++ b/kaze-hichau/Assets/Prefabs/TitleScene/title-2.png.meta
@@ -1,0 +1,156 @@
+fileFormatVersion: 2
+guid: 2c27d47cfc305ff4a8bbda55406822e0
+TextureImporter:
+  internalIDToNameTable:
+  - first:
+      213: 2161702166985848691
+    second: title-2_0
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 2
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites:
+    - serializedVersion: 2
+      name: title-2_0
+      rect:
+        serializedVersion: 2
+        x: 93
+        y: 11
+        width: 649
+        height: 269
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 377326deaa8effd10800000000000000
+      internalID: 2161702166985848691
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    outline: []
+    customData: 
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable:
+      title-2_0: 2161702166985848691
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/kaze-hichau/Assets/Prefabs/TitleScene/title-2_0.prefab
+++ b/kaze-hichau/Assets/Prefabs/TitleScene/title-2_0.prefab
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eaeddfa9cd029643467ca48734bb774f04d7b1b7487f38b5ebdb8332c0ce8abb
+size 2481

--- a/kaze-hichau/Assets/Prefabs/TitleScene/title-2_0.prefab.meta
+++ b/kaze-hichau/Assets/Prefabs/TitleScene/title-2_0.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9a032ba81d8cfbd409ba23212842a6c3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/kaze-hichau/Assets/Prefabs/hito 1.png
+++ b/kaze-hichau/Assets/Prefabs/hito 1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7cb61ae79acd8077f197d687f4a182908fab98621181df0a63c2b077fb15cf6
+size 103939

--- a/kaze-hichau/Assets/Prefabs/hito 1.png.meta
+++ b/kaze-hichau/Assets/Prefabs/hito 1.png.meta
@@ -1,0 +1,156 @@
+fileFormatVersion: 2
+guid: 09fb69575c933c4488b72916b96776cf
+TextureImporter:
+  internalIDToNameTable:
+  - first:
+      213: -759493636099001111
+    second: hito 1_0
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 2
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites:
+    - serializedVersion: 2
+      name: hito 1_0
+      rect:
+        serializedVersion: 2
+        x: 32
+        y: 200
+        width: 402
+        height: 525
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: -1
+      bones: []
+      spriteID: 9e4362bdf8cb575f0800000000000000
+      internalID: -759493636099001111
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    outline: []
+    customData: 
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable:
+      hito 1_0: -759493636099001111
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/kaze-hichau/Assets/Prefabs/hito 1_0.prefab
+++ b/kaze-hichau/Assets/Prefabs/hito 1_0.prefab
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72c5ece21d908890ac8926e4f5cdd5afebeb8112745bcf9ac890cf2be8155409
+size 2494

--- a/kaze-hichau/Assets/Prefabs/hito 1_0.prefab.meta
+++ b/kaze-hichau/Assets/Prefabs/hito 1_0.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 22869cfad20cd6b40b44fa50ad83cd35
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/kaze-hichau/Assets/Scenes/GameScene.unity
+++ b/kaze-hichau/Assets/Scenes/GameScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:747d1627cf5dd2af07a94107e6e9733f53db7e7c9b0920474741ba330cffc228
-size 32306
+oid sha256:5eec32dea3b439c5f2c83c904986e2f0da1b4d8e879f5a650148f892f70142a9
+size 37189

--- a/kaze-hichau/Assets/Scenes/HowToPlayScene.unity
+++ b/kaze-hichau/Assets/Scenes/HowToPlayScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:736db213028c33dcfa7215eb248910dc2e2657ae3575fd04ed62619fa0ee5adc
-size 17651
+oid sha256:786b5d99120e7643ef7d30be73eeec317b4fac3b0990e09defea05f630b65606
+size 17720

--- a/kaze-hichau/Assets/Scenes/ResultScene.unity
+++ b/kaze-hichau/Assets/Scenes/ResultScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:03d732abb5b855c5ab563f7c0910d55f35bba1974fa21ee94477d4e7303d0dc2
-size 28078
+oid sha256:6d313f1018e1ff6ea34a573b862b334a4b50de4c4b622ea67d48409171bed76f
+size 28983

--- a/kaze-hichau/Assets/Scenes/TitleScene.unity
+++ b/kaze-hichau/Assets/Scenes/TitleScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e6570878b3037c76a8a94b508a8cdd41b6cdbfcd4b255740fa90dabf5effbc0
-size 31466
+oid sha256:b542f0d3803fb923e106b075b0e5e3c6772987d66003add75d523e4cb0ba67dd
+size 31476

--- a/kaze-hichau/Assets/Scripts/BGM+SE.meta
+++ b/kaze-hichau/Assets/Scripts/BGM+SE.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a9f558419ffee094f8de1799a3f9cbbd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/kaze-hichau/Assets/Scripts/BGM+SE/BGMManager.cs
+++ b/kaze-hichau/Assets/Scripts/BGM+SE/BGMManager.cs
@@ -1,0 +1,85 @@
+using UnityEngine;
+using UnityEngine.SceneManagement; // シーン管理に必要
+
+public class BGMManager : MonoBehaviour
+{
+    public static BGMManager instance;
+    private AudioSource bgmSource;
+
+    [Header("BGMクリップ")]
+    public AudioClip titleBGM;     // タイトル画面用のBGM
+    public AudioClip gameplayBGM;  // ゲームプレイ中のBGM
+    public AudioClip resultBGM;    // リザルト画面用のBGM
+
+    private void OnEnable()
+    {
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    private void OnDisable()
+    {
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+    void Awake()
+    {
+        if (instance == null)
+        {
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    void Start()
+    {
+        bgmSource = GetComponent<AudioSource>();
+        // 最初にタイトルBGMをループ再生
+        ChangeBGM(titleBGM, true);
+    }
+
+    // シーンがロードされた時に呼ばれるメソッド
+    void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        AudioClip targetBGM = null;
+        bool loop = true; // デフォルトはループ再生
+
+        // シーン名に応じて再生するBGMとループ設定を決定
+        if (scene.name == "GameScene")
+        {
+            targetBGM = gameplayBGM;
+            loop = true;
+        }
+        else if (scene.name == "ResultScene")
+        {
+            targetBGM = resultBGM;
+            loop = false; // ★リザルト画面はループしない
+        }
+        else // TitleSceneやHow-to-playSceneなど、それ以外のシーン
+        {
+            targetBGM = titleBGM;
+            loop = true;
+        }
+
+        // BGMを変更
+        ChangeBGM(targetBGM, loop);
+    }
+
+    // BGMを変更するメソッド（ループ設定の引数を追加）
+    public void ChangeBGM(AudioClip musicClip, bool shouldLoop)
+    {
+        // 再生したいクリップが既に再生中で、ループ設定も同じなら何もしない
+        if (musicClip == null || (bgmSource.clip == musicClip && bgmSource.loop == shouldLoop))
+        {
+            return;
+        }
+
+        bgmSource.Stop();
+        bgmSource.clip = musicClip;
+        bgmSource.loop = shouldLoop; // ★ループ設定を反映
+        bgmSource.Play();
+    }
+}

--- a/kaze-hichau/Assets/Scripts/BGM+SE/BGMManager.cs.meta
+++ b/kaze-hichau/Assets/Scripts/BGM+SE/BGMManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8170c456e721dd048858219faee1c32e


### PR DESCRIPTION
このプルリクエストでは、プロジェクトに新しい背景音楽トラックとUI画像を追加し、これらのアセットをUnityシーンに統合するためのメタデータとプレハブファイルも含まれています。これらの変更により、タイトル、ゲーム、およびプレイ方法のシーンにおけるオーディオとビジュアルの体験が向上します。

**オーディオアセットの統合**
* 結果、タイトル、ゲームプレイシーン用の新しい背景音楽ファイル3つを追加しました：`ResultBGM.mp3`、`Title-bgm.mp3`、および`gamebgm.mp3`。それぞれに対応するUnityの`.meta`ファイルも追加し、インポート設定を定義しています。[[1]](diffhunk://#diff-638dbfa22af8ad78b18b366a9c15dab1f529232d35befe901c60675254d8fa4fR1-R3) [[2]](diffhunk://# diff-bc93fa50a3b5dda8b7f841731181ea13d0c1dd4e24eaa20817851ece964b7f49R1-R23) [[3]](diffhunk://# diff-fd3b82aa3852966ebbf71c581698d37d90379bde47eb582547e295d58a401935R1-R3) [[4]](diffhunk://# diff-45f6017979bcfd888983d8ad2f9e76b8d0152d782c216fe8ae6b3f436731fc91R1-R23) [[5]](diffhunk://# diff-9a21f8cf3eb5f4d8a59c7eb66569a43f6886b52721a8b3fab58b912e9ceca2d7R1-R3) [[6]](diffhunk://# diff-db6f1e3992cd5787e4fd275f08dd95583b3c66a6db8c286c293351fb436e63f5R1-R23)
* タイトルシーンでの背景音楽の再生を管理するため、`BGMManager.prefab` とその `.meta` ファイルを導入しました。[[1]](diffhunk://#diff-6d601611a524d64ad5a7aae28a7bcb2e755b9e2be318a210e93f61411dd90c61R1-R3) [[2]](diffhunk://# diff-5f94a4849ac7819fb199cb16ecf4810400366c57c7821a0fcd50ce6432988a89R1-R7)

**UI画像アセットの統合**
* 「How To Play」シーン用の新しいUIボタン画像を追加しました：`Play-button.png`と`title-button.png`、およびそれらのUnity `.meta`ファイル（スプライト設定を含む）。[[1]](diffhunk://#diff-dc8e24bd24940d7ba7cd1105321ad3f93c2ecdd1420d46adc9d94667115a9498R1-R3) [[2]](diffhunk://# diff-e9c94cede99f3ab3bff68c073de6bf9447aad6340350548b2fb577679b7b169dR1-R156) [[3]](diffhunk://# diff-35fb8d34ed6a50aed5dd719242bcef883af828e525d6afbb672f17ff6a48ae6bR1-R3) [[4]](diffhunk://# diff-cb0b1b5325daa63223af7d7e0f0c5cc7c412610b703d4df8d69b5216d9bddd0eR1-R156)
* タイトルシーン用の新しいタイトル画像 `title-2.png` とその `.meta` ファイル、およびシーンで画像を使用するための対応するプレハブと `.meta` ファイルを追加しました。[[1]](diffhunk://#diff-307d839967b30a875aebda896bf7eccd72f31be1233016f61d1d345f3fa79221R1-R3) [[2]](diffhunk://# diff-3b726df449e3361d27901490952895291d28fed4a36ac816ca7903c937d1f19eR1-R156) [[3]](diffhunk://# diff-7545f71f437b576fb64fbf0d41b9a620b1e82c0e05a36b28ce5fb9c6d2405a8cR1-R3) [[4]](diffhunk://# diff-d5b4629aa59b3d0760a283f62f812e63cbd5ab66a3b1f6b001df959a25f78486R1-R7)

**キャラクター画像の統合**
* 新しいキャラクター画像アセット `hito 1.png` とその `.meta` ファイル（スプライトインポート設定を含む）を追加し、シーンでスプライトを使用するためのプレハブも追加しました。[[1]](diffhunk://#diff-18acf5242a9df92ab7715aee32a3ff62d4112fce80f2b3c78711a5c6c63e332cR1-R3) [[2]](diffhunk://# diff-a0172e6f3b076002974ea603351879199f155683a8ed1a00a0d0564297251fe3R1-R156) [[3]](diffhunk://# diff-5eacb501e973f3e3e9498cff7501a45b37de7ee8feed0f309af5537eabf6149bR1-R3)

**プレファブ更新**
* 「How To Play」シーンの`Canvas.prefab`を更新しました。新しいUIアセットを参照するため、または新しい画像のレイアウトを調整するためです。